### PR TITLE
Fix SceneDTO to use correct object type

### DIFF
--- a/.changeset/thirty-sides-rush.md
+++ b/.changeset/thirty-sides-rush.md
@@ -1,0 +1,6 @@
+---
+"@bentley/scenes-client": patch
+---
+
+Fix SceneDTO type mismatch.
+`SceneDTO.sceneData.objects` now uses correct response `SceneObjectMinimalDTO` instead of `SceneObjectCreateDTO`.

--- a/packages/scenes-client/src/models/object/sceneObjectMinimal.dto.ts
+++ b/packages/scenes-client/src/models/object/sceneObjectMinimal.dto.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+import { isObject } from "../../utilities";
+import { SceneObjectDTO } from "./sceneObject.dto";
+import { isSceneObjectCreateDTO } from "./sceneObjectCreate.dto";
+
+export type SceneObjectMinimalDTO = Omit<
+  SceneObjectDTO,
+  "sceneId" | "createdById" | "creationTime" | "lastModified"
+>;
+
+export function isSceneObjectMinimalDTO(
+  v: unknown,
+): v is SceneObjectMinimalDTO {
+  return isObject(v) && typeof v.id === "string" && isSceneObjectCreateDTO(v);
+}

--- a/packages/scenes-client/src/models/scene/scene.dto.ts
+++ b/packages/scenes-client/src/models/scene/scene.dto.ts
@@ -1,20 +1,15 @@
 // Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 
 import { isObject } from "../../utilities";
-import {
-  isSceneDataCreateDTO,
-  SceneCreateDTO,
-  SceneDataCreateDTO,
-} from "./sceneCreate.dto";
+import { SceneCreateDTO } from "./sceneCreate.dto";
+import { isSceneDataDTO, SceneDataDTO } from "./sceneData.dto";
 
 export interface SceneDTO extends SceneCreateDTO {
   /** Unique identifier for the scene (UUID). */
   id: string;
   /** Scene informational objects. */
-  sceneData: SceneDataCreateDTO;
-  /**
-   * Indicates sceneData was filtered because the user lacks necessary permissions to view all objects.
-   */
+  sceneData: SceneDataDTO;
+  /** Indicates sceneData was filtered because the user lacks necessary permissions to view all objects. */
   isPartial?: boolean;
   /** Id of the user who created the scene (UUID). */
   createdById: string;
@@ -30,7 +25,7 @@ export function isSceneDTO(v: unknown): v is SceneDTO {
   return (
     isObject(v) &&
     typeof v.id === "string" &&
-    isSceneDataCreateDTO(v.sceneData) &&
+    isSceneDataDTO(v.sceneData) &&
     (v.isPartial === undefined || typeof v.isPartial === "boolean") &&
     typeof v.createdById === "string" &&
     typeof v.iTwinId === "string" &&

--- a/packages/scenes-client/src/models/scene/sceneData.dto.ts
+++ b/packages/scenes-client/src/models/scene/sceneData.dto.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+
+import { isObject } from "../../utilities";
+import {
+  isSceneObjectMinimalDTO,
+  SceneObjectMinimalDTO,
+} from "../object/sceneObjectMinimal.dto";
+
+/** Container for scene objects and related data returned by the API */
+export interface SceneDataDTO {
+  /** Array of scene objects */
+  objects: SceneObjectMinimalDTO[];
+}
+
+export function isSceneDataDTO(v: unknown): v is SceneDataDTO {
+  return (
+    isObject(v) &&
+    Array.isArray(v.objects) &&
+    v.objects.every((obj) => isSceneObjectMinimalDTO(obj))
+  );
+}


### PR DESCRIPTION
`SceneDTO` was incorrectly using `SceneObjectCreateDTO`, which has an optional id.
Updated to reflect the actual response.

Related to #14 