### PR TITLE
Move iTwinId from metadata to RepositoryResource schema

### DIFF
--- a/.changeset/clever-things-swim.md
+++ b/.changeset/clever-things-swim.md
@@ -1,0 +1,10 @@
+---
+"@bentley/scenes-client": minor
+---
+
+Move `iTwinId` from metadata to `RepositoryResource` schema
+
+**Breaking Changes:**
+- Remove `ITwinScopedObjectCreate` and `ITwinScopedObject` interfaces
+- Add `iTwinId` as required field in `RepositoryResource` schema data
+- Consolidate object update interfaces into single `SceneObjectUpdate` interface for all kinds

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,9 +26,9 @@ Scene objects are:
 {
   "kind": "Layer",
   "version": "1.0.0",
+  "displayName": "Exton Campus - Main Building",
   "data": {
-    "visible": true,
-    "displayName": "Exton Campus - Main Building"
+    "visible": true
   }
 }
 ```
@@ -43,8 +43,8 @@ Scene objects are:
   "displayName": "Main Building Model",
   "kind": "RepositoryResource",
   "version": "1.0.0",
-  "iTwinId": "fa6e86b2-da9a-4fdc-a1bd-4a707b696d32",
   "data": {
+    "iTwinId": "fa6e86b2-da9a-4fdc-a1bd-4a707b696d32",
     "class": "iModels",
     "repositoryId": "iModels",
     "id": "c2fdfb84-bedb-409d-8527-fe519c85abe2",
@@ -131,9 +131,9 @@ Scene: "Construction Site Overview"
         "id": "709f6a9d-d791-4e6c-9154-1b8fffbab3c1",
         "kind": "Layer",
         "version": "1.0.0",
+        "displayName": "Buildings",
         "data": {
-          "visible": true,
-          "displayName": "Buildings"
+          "visible": true
         }
       },
 
@@ -144,8 +144,8 @@ Scene: "Construction Site Overview"
         "kind": "RepositoryResource",
         "version": "1.0.0",
         "parentId": "709f6a9d-d791-4e6c-9154-1b8fffbab3c1", // References Buildings Layer
-        "iTwinId": "64060a14-d545-4fff-b3b0-4c31291e7a00",
         "data": {
+          "iTwinId": "64060a14-d545-4fff-b3b0-4c31291e7a00",
           "class": "iModels",
           "repositoryId": "iModels",
           "id": "ba9bdbbf-59f9-41aa-a4e3-6fbd8d6bd068",
@@ -178,9 +178,9 @@ Scene: "Construction Site Overview"
         "id": "3bc3a0c0-75e8-498b-901a-7290f57f7b40",
         "kind": "Layer",
         "version": "1.0.0",
+        "displayName": "Utilities",
         "data": {
-          "visible": true,
-          "displayName": "Utilities"
+          "visible": true
         }
       },
 
@@ -191,8 +191,8 @@ Scene: "Construction Site Overview"
         "kind": "RepositoryResource",
         "version": "1.0.0",
         "parentId": "3bc3a0c0-75e8-498b-901a-7290f57f7b40", // References Utilities Layer
-        "iTwinId": "64060a14-d545-4fff-b3b0-4c31291e7a00",
         "data": {
+          "iTwinId": "64060a14-d545-4fff-b3b0-4c31291e7a00",
           "class": "iModels",
           "repositoryId": "iModels",
           "id": "6bbcf593-6160-4d83-9c07-1a69e4cc29fb",

--- a/packages/scenes-client/README.md
+++ b/packages/scenes-client/README.md
@@ -223,15 +223,15 @@ const layer: LayerCreate = {
   },
 };
 
-// Note: RepositoryResourceCreate is an alias for ITwinScopedObjectCreate<"RepositoryResource", "1.0.0">
+// Note: RepositoryResourceCreate is an alias for StandardObjectCreate<"RepositoryResource", "1.0.0">
 const iModelResource: RepositoryResourceCreate = {
   id: "<imodel_object_id>",
   kind: "RepositoryResource",
   version: "1.0.0",
   displayName: "Main Building Model",
   parentId: "<layer_id>", // Organize under the layer
-  iTwinId: "<itwin_id>", // Required for iTwin-scoped objects
   data: {
+    iTwinId: "<itwin_id>",
     class: "iModels",
     repositoryId: "iModels",
     id: "<imodel_id>",
@@ -291,10 +291,10 @@ createResponse.objects.forEach((obj: SceneObject) => {
 #### Update Scene Objects
 
 ```ts
-import { SceneObjectUpdate, SceneObjectUpdateById, MetadataSceneObjectUpdate, StandardSceneObjectDataUpdate } from "@bentley/scenes-client";
+import { SceneObjectUpdate, SceneObjectUpdateById } from "@bentley/scenes-client";
 
 // Update data for a specific object with type safety
-const objectUpdate: StandardSceneObjectDataUpdate<"GoogleTilesStyling", "1.0.0"> = {
+const objectUpdate: SceneObjectUpdate<"GoogleTilesStyling", "1.0.0"> = {
   displayName: "Updated Global Styling Options",
   data: { // Fully typed - IntelliSense shows available properties
     quality: 0.30000001192092896,
@@ -349,7 +349,7 @@ await client.deleteObjects({
 This client provides strongly typed interfaces for all scene object operations, giving you compile-time validation:
 
 ```ts
-import { StandardObjectCreate, ITwinScopedObjectCreate, ResourceStylingObjectCreate } from "@bentley/scenes-client";
+import { StandardObjectCreate, ResourceStylingObjectCreate } from "@bentley/scenes-client";
 
 // Each schema has its own typed interface
 const camera: StandardObjectCreate<"CameraAnimation", "1.0.0"> = {
@@ -368,20 +368,6 @@ const camera: StandardObjectCreate<"CameraAnimation", "1.0.0"> = {
         },
       },
     ],
-  },
-};
-
-// iTwin-scoped objects automatically require iTwinId
-const repository: ITwinScopedObjectCreate<"RepositoryResource", "1.0.0"> = {
-  kind: "RepositoryResource",
-  version: "1.0.0",
-  iTwinId: "<itwin_id>", // TypeScript enforces this field
-  data: {
-    // IntelliSense shows RepositoryResource specific properties
-    class: "iModels",
-    repositoryId: "iModels",
-    id: "<imodel_id>",
-    visible: true,
   },
 };
 

--- a/packages/scenes-client/src/models/object/sceneObject.ts
+++ b/packages/scenes-client/src/models/object/sceneObject.ts
@@ -3,12 +3,10 @@ import { isObject } from "../../utilities.js";
 import {
   isSceneObjectCreate,
   ResourceStylingObjectCreate,
-  ITwinScopedObjectCreate,
   StandardObjectCreate,
 } from "./sceneObjectCreate.js";
 import { SchemaVersion } from "./types/sceneObjectSchemas.js";
 import {
-  ITwinScopedSchemas,
   ResourceStylingSchemas,
   StandardSchemas,
 } from "./types/schemaCategories.js";
@@ -40,16 +38,7 @@ export interface ResourceStylingObject<
     SceneObjectResponseMetadata {}
 
 /**
- * Scene object that is iTwin-scoped (ex: RepositoryResource)
- */
-export interface ITwinScopedObject<
-  K extends ITwinScopedSchemas = ITwinScopedSchemas,
-  V extends SchemaVersion<K> = SchemaVersion<K>,
-> extends Omit<ITwinScopedObjectCreate<K, V>, "id">,
-    SceneObjectResponseMetadata {}
-
-/**
- * Standard scene object (ex: Layer, View3d, UnrealAtmosphericStyling)
+ * Standard scene object (ex: Layer, RepositoryResource, View3d, UnrealAtmosphericStyling)
  */
 export interface StandardObject<
   K extends StandardSchemas = StandardSchemas,
@@ -61,10 +50,7 @@ export interface StandardObject<
  * Union type representing all possible scene object responses.
  * Automatically resolves to the appropriate interface based on schema kind
  */
-export type SceneObject =
-  | StandardObject
-  | ResourceStylingObject
-  | ITwinScopedObject;
+export type SceneObject = StandardObject | ResourceStylingObject;
 
 export function isSceneObject(v: unknown): v is SceneObject {
   return (

--- a/packages/scenes-client/src/models/object/sceneObjectCreate.ts
+++ b/packages/scenes-client/src/models/object/sceneObjectCreate.ts
@@ -6,7 +6,6 @@ import {
   SchemaVersion,
 } from "./types/sceneObjectSchemas.js";
 import {
-  ITwinScopedSchemas,
   ResourceStylingSchemas,
   StandardSchemas,
 } from "./types/schemaCategories.js";
@@ -59,28 +58,6 @@ export interface ResourceStylingObjectCreate<
 }
 
 /**
- * iTwin-scoped object creation interface.
- * Object will be associated to a specific iTwin via iTwinId
- *
- * @example
- * ```typescript
- * const repository: ITwinScopedObjectCreate = {
- *   kind: 'RepositoryResource',
- *   version: '1.0.0',
- *   iTwinId: '<iTwin_id>',
- *   data: { repositoryId: '<repo_id>',  id: '<resource_id>', class: '<repo_class>', visible: true }
- * };
- * ```
- */
-export interface ITwinScopedObjectCreate<
-  K extends ITwinScopedSchemas = ITwinScopedSchemas,
-  V extends SchemaVersion<K> = SchemaVersion<K>,
-> extends BaseSceneObjectCreate<K, V> {
-  /** iTwin Id the scene object is associated with (UUID) */
-  iTwinId: string;
-}
-
-/**
  * Standard scene object creation interface.
  * Use for most objects, no extra requirements beyond base properties
  */
@@ -96,8 +73,7 @@ export interface StandardObjectCreate<
  */
 export type SceneObjectCreate =
   | StandardObjectCreate
-  | ResourceStylingObjectCreate
-  | ITwinScopedObjectCreate;
+  | ResourceStylingObjectCreate;
 
 /**
  * Interface for creating multiple scene objects
@@ -125,7 +101,6 @@ export function isSceneObjectCreate(v: unknown): v is SceneObjectCreate {
     typeof v.version === "string" &&
     typeof v.kind === "string" &&
     (v.parentId === undefined || typeof v.parentId === "string") &&
-    (v.iTwinId === undefined || typeof v.iTwinId === "string") &&
     (v.relatedId === undefined || typeof v.relatedId === "string") &&
     isObject(v.data)
   );

--- a/packages/scenes-client/src/models/object/sceneObjectUpdate.ts
+++ b/packages/scenes-client/src/models/object/sceneObjectUpdate.ts
@@ -1,67 +1,12 @@
 // Copyright (c) Bentley Systems, Incorporated. All rights reserved.
-import { SchemaData, SchemaVersion } from "./types/sceneObjectSchemas.js";
 import {
-  ITwinScopedSchemas,
-  ResourceStylingSchemas,
-  StandardSchemas,
-} from "./types/schemaCategories.js";
+  SchemaData,
+  SchemaKind,
+  SchemaVersion,
+} from "./types/sceneObjectSchemas.js";
 
 /**
- * Optional metadata properties that can be updated for any scene object
- */
-export interface MetadataSceneObjectUpdate {
-  /** Display name for the scene object */
-  displayName?: string;
-  /** Number for the scene object's order in lists */
-  order?: number;
-  /** Parent Id for the scene object (UUID) */
-  parentId?: string;
-}
-
-/**
- * Interface for updating resource styling object data (and optionally metadata)
- *
- * @example
- * ```typescript
- * const stylingUpdate: ResourceStylingObjectUpdate<'ExpressionStyling', '1.0.0'> = {
- *   displayName: 'Updated Expression',
- *   data: { stylingOptions: { styleType: "Expression", show: 'element.category === "Door"' } }
- * };
- * ```
- */
-export interface ResourceStylingObjectDataUpdate<
-  K extends ResourceStylingSchemas,
-  V extends SchemaVersion<K> = SchemaVersion<K>,
-> extends MetadataSceneObjectUpdate {
-  /** Schema-specific data to update for the resource styling scene object */
-  data: SchemaData<K, V>;
-}
-
-/**
- * Interface for updating iTwin scoped object data (and optionally metadata)
- * When updating data, iTwinId is required
- *
- * @example
- * ```typescript
- * const repositoryUpdate: ITwinScopedObjectUpdate<'RepositoryResource', '1.0.0'> = {
- *   displayName: 'Updated Repository',
- *   iTwinId: '<iTwin_id>',
- *   data: { repositoryId: '<repo_id>',  id: '<resource_id>', class: '<repo_class>', visible: true }
- * };
- * ```
- */
-export interface ITwinScopedObjectDataUpdate<
-  K extends ITwinScopedSchemas = ITwinScopedSchemas,
-  V extends SchemaVersion<K> = SchemaVersion<K>,
-> extends MetadataSceneObjectUpdate {
-  /** iTwin Id the scene object is associated with (UUID) */
-  iTwinId: string;
-  /** Schema-specific data to update for the scene object */
-  data: SchemaData<K, V>;
-}
-
-/**
- * Interface for updating standard scene object data (and optionally metadata)
+ * Interface for updating scene objects
  *
  * @example
  * ```typescript
@@ -71,22 +16,19 @@ export interface ITwinScopedObjectDataUpdate<
  * };
  * ```
  */
-export interface StandardSceneObjectDataUpdate<
-  K extends StandardSchemas,
+export interface SceneObjectUpdate<
+  K extends SchemaKind = SchemaKind,
   V extends SchemaVersion<K> = SchemaVersion<K>,
-> extends MetadataSceneObjectUpdate {
+> {
+  /** Display name for the scene object */
+  displayName?: string;
+  /** Number for the scene object's order in lists */
+  order?: number;
+  /** Parent Id for the scene object (UUID) */
+  parentId?: string;
   /** Schema-specific data to update for the scene object */
-  data: SchemaData<K, V>;
+  data?: SchemaData<K, V>;
 }
-
-/**
- * Union type representing all possible scene object updates
- */
-export type SceneObjectUpdate =
-  | MetadataSceneObjectUpdate
-  | ResourceStylingObjectDataUpdate<ResourceStylingSchemas>
-  | ITwinScopedObjectDataUpdate<ITwinScopedSchemas>
-  | StandardSceneObjectDataUpdate<StandardSchemas>;
 
 export type SceneObjectUpdateById = SceneObjectUpdate & {
   /** Id of the scene object to update (UUID) */

--- a/packages/scenes-client/src/models/object/types/sceneObjectSchemas.ts
+++ b/packages/scenes-client/src/models/object/types/sceneObjectSchemas.ts
@@ -140,6 +140,8 @@ export interface ScenesApiSchemas {
     "1.0.0": {
       /** Whether the layer is turned on or off */
       visible: boolean;
+      /** Id of the iTwin this repository resource is associated with */
+      iTwinId: Guid;
       /** Id of the repository. Should be the same as class for internal repos and a GUID for custom repos */
       repositoryId: SafeString;
       /** Id of the individual resource */

--- a/packages/scenes-client/src/models/object/types/sceneObjectTypes.ts
+++ b/packages/scenes-client/src/models/object/types/sceneObjectTypes.ts
@@ -1,12 +1,7 @@
 // Copyright (c) Bentley Systems, Incorporated. All rights reserved.
-import type {
-  ResourceStylingObject,
-  ITwinScopedObject,
-  StandardObject,
-} from "../sceneObject.js";
+import type { ResourceStylingObject, StandardObject } from "../sceneObject.js";
 import type {
   ResourceStylingObjectCreate,
-  ITwinScopedObjectCreate,
   StandardObjectCreate,
 } from "../sceneObjectCreate.js";
 
@@ -43,7 +38,7 @@ export type MovieCreateV1 = StandardObjectCreate<"Movie", "1.0.0">;
 export type MovieCreate = MovieCreateV1;
 
 /** RepositoryResource (v1.0.0) Scene Object Creation Type */
-export type RepositoryResourceCreateV1 = ITwinScopedObjectCreate<
+export type RepositoryResourceCreateV1 = StandardObjectCreate<
   "RepositoryResource",
   "1.0.0"
 >;
@@ -141,7 +136,7 @@ export type MovieV1 = StandardObject<"Movie", "1.0.0">;
 export type Movie = MovieV1;
 
 /** RepositoryResource (v1.0.0) Scene Object Response Type. */
-export type RepositoryResourceV1 = ITwinScopedObject<
+export type RepositoryResourceV1 = StandardObject<
   "RepositoryResource",
   "1.0.0"
 >;

--- a/packages/scenes-client/src/models/object/types/schemaCategories.ts
+++ b/packages/scenes-client/src/models/object/types/schemaCategories.ts
@@ -8,11 +8,5 @@ export type ResourceStylingSchemas =
   | "iModelVisibility"
   | "RealityDataStyling";
 
-/** Schemas that define iTwin-scoped resources */
-export type ITwinScopedSchemas = "RepositoryResource";
-
 /** Standard schemas without additional metadata requirements */
-export type StandardSchemas = Exclude<
-  SchemaKind,
-  ResourceStylingSchemas | ITwinScopedSchemas
->;
+export type StandardSchemas = Exclude<SchemaKind, ResourceStylingSchemas>;

--- a/packages/scenes-client/tests/integration.test.ts
+++ b/packages/scenes-client/tests/integration.test.ts
@@ -30,8 +30,8 @@ const LAYER_OBJ: SceneObjectCreate = {
 const REPO_OBJ: SceneObjectCreate = {
   kind: "RepositoryResource",
   version: "1.0.0",
-  iTwinId: ITWIN_ID,
   data: {
+    iTwinId: ITWIN_ID,
     visible: true,
     id: IMODEL_ID,
     class: "iModels",


### PR DESCRIPTION
iTwinId was previously required in metadata for repository resources and disallowed for all other object kinds.

iTwinId has been moved to the actual RepositoryResource schema instead. Now all relevant info to call repo api is grouped together.

Related to https://github.com/iTwin/scenes/pull/333 and https://github.com/iTwin/scenes/issues/321 

