### PR TITLE
Add supported repository classes

### DIFF
--- a/.changeset/cold-hairs-take.md
+++ b/.changeset/cold-hairs-take.md
@@ -1,0 +1,8 @@
+---
+"@bentley/scenes-client": patch
+---
+
+Add list of supported repository classes for "Repository" objects
+
+- Added `SUPPORTED_REPOSITORIES` constant and `SupportedRepository` type.
+- Added `isSupportedRepository()` function to check if a repository class is supported.

--- a/packages/scenes-client/src/models/index.ts
+++ b/packages/scenes-client/src/models/index.ts
@@ -11,6 +11,7 @@ export * from "./object/sceneObjectUpdate.js";
 export * from "./object/types/sceneObjectSchemas.js";
 export * from "./object/types/sceneObjectTypes.js";
 export * from "./object/types/schemaCategories.js";
+export * from "./object/types/supportedRepositories.js";
 
 export * from "./scene/getScenesOptions.js";
 export * from "./scene/scene.js";

--- a/packages/scenes-client/src/models/object/types/sceneObjectSchemas.ts
+++ b/packages/scenes-client/src/models/object/types/sceneObjectSchemas.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+import { SupportedRepository } from "./supportedRepositories.js";
 
 // CommonTypes interfaces
 /** GUID string */
@@ -147,7 +148,7 @@ export interface ScenesApiSchemas {
       /** Id of the repository. Should be the same as class for internal repos and a GUID for custom repos */
       repositoryId: SafeString;
       /** Class of the repository, such as IndexedMedia or Forms */
-      class: SafeString;
+      class: SupportedRepository;
       /** SubClass of the repository if applicable */
       subClass?: SafeString;
     };

--- a/packages/scenes-client/src/models/object/types/supportedRepositories.ts
+++ b/packages/scenes-client/src/models/object/types/supportedRepositories.ts
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+/** Repository classes that can be added to a scene in their entirety as "Repository" objects. */
+export const SUPPORTED_REPOSITORIES = ["IndexedMedia", "Forms", "Storage"] as const;
+
+/** Type representing all supported "Repository" object classes. */
+export type SupportedRepository = (typeof SUPPORTED_REPOSITORIES)[number];
+
+/**
+ * Checks if the value is a supported "Repository" object class.
+ * @param repoClass The repository class to check
+ * @returns True if the repository class is supported as a "Repository" object, false otherwise.
+ */
+export function isSupportedRepository(repoClass: unknown): repoClass is SupportedRepository {
+  return SUPPORTED_REPOSITORIES.includes(repoClass as SupportedRepository);
+}


### PR DESCRIPTION
Related to https://github.com/iTwin/scenes/issues/287#issuecomment-3302735219

Enables scenes-control to check if a repository class is supported for "add to scene" actions
