### PR TITLE
Fix handling of optional properties on create/update requests

### DIFF
--- a/.changeset/evil-spiders-show.md
+++ b/.changeset/evil-spiders-show.md
@@ -2,7 +2,7 @@
 "@itwin/scenes-client": patch
 ---
 
-Fix handling optional fields on POST/PATCH requests
+Fix handling optional fields in create and patch functions
 
 - Ignore undefined values in Scene/SceneObject payloads
 - Allow passing `null` to explicitly remove optional fields

--- a/.changeset/evil-spiders-show.md
+++ b/.changeset/evil-spiders-show.md
@@ -1,0 +1,8 @@
+---
+"@itwin/scenes-client": patch
+---
+
+Fix handling optional fields on POST/PATCH requests
+
+- Ignore undefined values in Scene/SceneObject payloads
+- Allow passing `null` to explicitly remove optional fields

--- a/packages/scenes-client/src/api/sceneApi.ts
+++ b/packages/scenes-client/src/api/sceneApi.ts
@@ -229,7 +229,7 @@ export async function postScene({
     },
     fetchOptions: {
       method: "POST",
-      body: JSON.stringify(scene, (_, value) => (value === undefined ? null : value)),
+      body: JSON.stringify(scene),
     },
     additionalHeaders: {
       Accept: "application/vnd.bentley.itwin-platform.v1+json",
@@ -273,7 +273,7 @@ export async function patchScene({
     },
     fetchOptions: {
       method: "PATCH",
-      body: JSON.stringify(scene, (_, value) => (value === undefined ? null : value)),
+      body: JSON.stringify(scene),
     },
     additionalHeaders: {
       Accept: "application/vnd.bentley.itwin-platform.v1+json",

--- a/packages/scenes-client/src/api/sceneObjectApi.ts
+++ b/packages/scenes-client/src/api/sceneObjectApi.ts
@@ -184,9 +184,7 @@ export async function postObjects({
       },
       fetchOptions: {
         method: "POST",
-        body: JSON.stringify({ objects: batch }, (_, value) =>
-          value === undefined ? null : value,
-        ),
+        body: JSON.stringify({ objects: batch }),
       },
       additionalHeaders: {
         Accept: "application/vnd.bentley.itwin-platform.v1+json",
@@ -237,7 +235,7 @@ export async function patchObject({
     },
     fetchOptions: {
       method: "PATCH",
-      body: JSON.stringify(object, (_, value) => (value === undefined ? null : value)),
+      body: JSON.stringify(object),
     },
     additionalHeaders: {
       Accept: "application/vnd.bentley.itwin-platform.v1+json",
@@ -284,9 +282,7 @@ export async function patchObjects({
       },
       fetchOptions: {
         method: "PATCH",
-        body: JSON.stringify({ objects: batch }, (_, value) =>
-          value === undefined ? null : value,
-        ),
+        body: JSON.stringify({ objects: batch }),
       },
       additionalHeaders: {
         Accept: "application/vnd.bentley.itwin-platform.v1+json",

--- a/packages/scenes-client/src/models/object/sceneObjectUpdate.ts
+++ b/packages/scenes-client/src/models/object/sceneObjectUpdate.ts
@@ -19,12 +19,12 @@ export interface SceneObjectUpdate<
   K extends SchemaKind = SchemaKind,
   V extends SchemaVersion<K> = SchemaVersion<K>,
 > {
-  /** Display name for the scene object */
-  displayName?: string;
-  /** Number for the scene object's order in lists */
-  order?: number;
-  /** Parent Id for the scene object (UUID) */
-  parentId?: string;
+  /** Optional display name for the scene object. Pass `null` to remove. */
+  displayName?: string | null;
+  /** Optional number for the scene object's order in lists. Pass `null` to remove. */
+  order?: number | null;
+  /** Optional parent Id for the scene object (UUID). Pass `null` to remove. */
+  parentId?: string | null;
   /** Schema-specific data to update for the scene object */
   data?: SchemaData<K, V>;
 }

--- a/packages/scenes-client/src/models/scene/sceneUpdate.ts
+++ b/packages/scenes-client/src/models/scene/sceneUpdate.ts
@@ -6,8 +6,8 @@
 export interface SceneUpdate {
   /** User defined display name of the scene */
   displayName?: string;
-  /** Optional detailed description of the scene */
-  description?: string;
-  /** Optional parent Id for the scene (UUID) */
-  parentId?: string;
+  /** Optional detailed description of the scene. Pass `null` to remove. */
+  description?: string | null;
+  /** Optional parent Id for the scene (UUID). Pass `null` to remove. */
+  parentId?: string | null;
 }

--- a/packages/scenes-client/tests/integration.test.ts
+++ b/packages/scenes-client/tests/integration.test.ts
@@ -41,7 +41,11 @@ const REPO_OBJ: SceneObjectCreate = {
 };
 
 const TEST_SCENES: SceneCreate[] = [
-  { displayName: "TestSceneA", sceneData: { objects: [LAYER_OBJ, REPO_OBJ] } },
+  {
+    displayName: "TestSceneA",
+    description: "DescriptionA",
+    sceneData: { objects: [LAYER_OBJ, REPO_OBJ] },
+  },
   { displayName: "TestSceneB", sceneData: { objects: [LAYER_OBJ, REPO_OBJ] } },
 ];
 
@@ -95,6 +99,7 @@ describe("Scenes operation", () => {
     // Basic identity checks
     expect(res.scene.id).toBe(sceneAId);
     expect(res.scene.displayName).toBe("TestSceneA");
+    expect(res.scene.description).toBe("DescriptionA");
     expect(res.scene.iTwinId).toBe(ITWIN_ID);
 
     // Verify the sceneData.objects array contains both objects
@@ -151,6 +156,15 @@ describe("Scenes operation", () => {
 
     expect(upd.scene.displayName).toBe("UpdatedA");
     expect(upd.scene.description).toBe("UpdateB");
+
+    const upd2 = await client.patchScene({
+      iTwinId: ITWIN_ID,
+      sceneId: sceneAId,
+      scene: { displayName: undefined, description: null },
+    });
+
+    expect(upd2.scene.displayName).toBe("UpdatedA"); // ignored displayName
+    expect(upd2.scene.description).toBe(undefined); // removed optional description
   });
 
   it("delete scene", async () => {
@@ -215,9 +229,19 @@ describe("Scenes Objects operations", () => {
       iTwinId: ITWIN_ID,
       sceneId,
       objectId: obj1,
-      object: { displayName: "Layer1Up" },
+      object: { displayName: undefined, order: 2 },
     });
-    expect(p1.object.displayName).toBe("Layer1Up");
+    expect(p1.object.displayName).toBe("TestLayer"); // ignored displayName
+    expect(p1.object.order).toBe(2); // updated order
+
+    const p2 = await client.patchObject({
+      iTwinId: ITWIN_ID,
+      sceneId,
+      objectId: obj1,
+      object: { displayName: null, order: null },
+    });
+    expect(p2.object.displayName).toBe(undefined); // removed displayName
+    expect(p2.object.order).toBe(undefined); // removed order
   });
 
   it("patches objects", async () => {


### PR DESCRIPTION
Fixes https://github.com/iTwin/scenes-client/issues/61

The client was replacing all instances of `undefined` with `null` on post/patch. It should not have been transforming request payload at all - Scenes API will accept/ignore `undefined` for optional props. 

Removed this transformation
Updated to allow passing `null` for explicitly removing optional fields